### PR TITLE
Remote headers

### DIFF
--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -70,7 +70,7 @@ the definition of all other Python objects.
 
    This macro is used to access the :attr:`ob_refcnt` member of a Python
    object.
-   It expands to::
+   It might expand to::
 
       (((PyObject*)(o))->ob_refcnt)
 

--- a/Include/object.h
+++ b/Include/object.h
@@ -833,7 +833,6 @@ Py_LOCAL_INLINE(int) __py_incref__(PyObject *o) {
     py_time_refcounts_t *t = PyState_GetThisThreadPyTimeRefcounts();
     _Py_INC_REFTOTAL;
     start = fast_get_cycles();
-    __sync_fetch_and_add(&_Py_REFCNT(o), 1);
     ATOMIC_INC(&_Py_REFCNT(o));
     delta = fast_get_cycles() - start;
     PY_TIME_FETCH_AND_ADD(t, total_refcount_time, delta);

--- a/Include/object.h
+++ b/Include/object.h
@@ -65,6 +65,7 @@ whose size is determined when the object is allocated.
 #error Py_LIMITED_API is incompatible with Py_DEBUG, Py_TRACE_REFS, and Py_REF_DEBUG
 #endif
 
+
 #ifdef Py_TRACE_REFS
 /* Define pointers to support a doubly-linked list of all live heap objects. */
 #define _PyObject_HEAD_EXTRA            \

--- a/Include/object.h
+++ b/Include/object.h
@@ -484,12 +484,17 @@ typedef struct {
     Py_ssize_t ob_size; /* Number of items in variable part */
 } PyVarObject;
 
+/* API Functions for allocating the refcount. */
 void _PyRefcount_New(PyObject *);
 void _PyRefcount_Del(PyObject *);
 
+/* Read-only access to the refcount (for most uses). */
 #define Py_REFCNT(ob)           ((const Py_ssize_t)*(((PyObject*)(ob))->ob_refcnt_ptr))
+/* Read-write access to the refcount (without checking pointer validity). */
 #define _Py_REFCNT(ob)          (*((PyObject*)(ob))->ob_refcnt_ptr)
+/* Assignment to refcount, without checking pointer validity. */
 #define Py_SET_REFCNT(ob, val)  (_Py_REFCNT(ob) = (val))
+
 #define Py_TYPE(ob)             (((PyObject*)(ob))->ob_type)
 #define Py_SIZE(ob)             (((PyVarObject*)(ob))->ob_size)
 
@@ -1156,6 +1161,9 @@ PyAPI_FUNC(void) _Py_Dealloc(PyObject *);
 #endif
 #endif /* !Py_TRACE_REFS */
 
+/* For PyModuleDefs and other objects that are statically initialized,
+ * allocate the refcount iff it isn't already allocated. Can't do this in
+ * the general case as the object may consist of uninitialized memory. */
 #define _Py_MaybeNewReference(op) (                     \
     ((PyObject *)(op))->ob_refcnt_ptr == NULL ? _Py_NewReference(op) : 0)
 

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -541,7 +541,7 @@ functools_reduce(PyObject *self, PyObject *args)
     for (;;) {
         PyObject *op2;
 
-        if (args->ob_refcnt > 1) {
+        if (Py_REFCNT(args) > 1) {
             Py_DECREF(args);
             if ((args = PyTuple_New(2)) == NULL)
                 goto Fail;

--- a/Modules/_testbuffer.c
+++ b/Modules/_testbuffer.c
@@ -2836,10 +2836,12 @@ PyInit__testbuffer(void)
         return NULL;
 
     Py_TYPE(&NDArray_Type) = &PyType_Type;
+    PyType_Ready(&NDArray_Type);
     Py_INCREF(&NDArray_Type);
     PyModule_AddObject(m, "ndarray", (PyObject *)&NDArray_Type);
 
     Py_TYPE(&StaticArray_Type) = &PyType_Type;
+    PyType_Ready(&StaticArray_Type);
     Py_INCREF(&StaticArray_Type);
     PyModule_AddObject(m, "staticarray", (PyObject *)&StaticArray_Type);
 

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -2710,8 +2710,8 @@ slot_tp_del(PyObject *self)
     PyObject *error_type, *error_value, *error_traceback;
 
     /* Temporarily resurrect the object. */
-    assert(self->ob_refcnt == 0);
-    self->ob_refcnt = 1;
+    assert(Py_REFCNT(self) == 0);
+    Py_REFCNT(self) = 1;
 
     /* Save the current exception, if any. */
     PyErr_Fetch(&error_type, &error_value, &error_traceback);
@@ -2733,17 +2733,17 @@ slot_tp_del(PyObject *self)
     /* Undo the temporary resurrection; can't use DECREF here, it would
      * cause a recursive call.
      */
-    assert(self->ob_refcnt > 0);
-    if (--self->ob_refcnt == 0)
+    assert(Py_REFCNT(self) > 0);
+    if (--Py_REFCNT(self) == 0)
         return;         /* this is the normal path out */
 
     /* __del__ resurrected it!  Make it look like the original Py_DECREF
      * never happened.
      */
     {
-        Py_ssize_t refcnt = self->ob_refcnt;
+        Py_ssize_t refcnt = Py_REFCNT(self);
         _Py_NewReference(self);
-        self->ob_refcnt = refcnt;
+        Py_REFCNT(self) = refcnt;
     }
     assert(!PyType_IS_GC(Py_TYPE(self)) ||
            _Py_AS_GC(self)->gc.gc_refs != _PyGC_REFS_UNTRACKED);

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -2711,7 +2711,7 @@ slot_tp_del(PyObject *self)
 
     /* Temporarily resurrect the object. */
     assert(Py_REFCNT(self) == 0);
-    Py_REFCNT(self) = 1;
+    _Py_REFCNT(self) = 1;
 
     /* Save the current exception, if any. */
     PyErr_Fetch(&error_type, &error_value, &error_traceback);
@@ -2734,7 +2734,7 @@ slot_tp_del(PyObject *self)
      * cause a recursive call.
      */
     assert(Py_REFCNT(self) > 0);
-    if (--Py_REFCNT(self) == 0)
+    if (--_Py_REFCNT(self) == 0)
         return;         /* this is the normal path out */
 
     /* __del__ resurrected it!  Make it look like the original Py_DECREF
@@ -2743,7 +2743,7 @@ slot_tp_del(PyObject *self)
     {
         Py_ssize_t refcnt = Py_REFCNT(self);
         _Py_NewReference(self);
-        Py_REFCNT(self) = refcnt;
+        _Py_REFCNT(self) = refcnt;
     }
     assert(!PyType_IS_GC(Py_TYPE(self)) ||
            _Py_AS_GC(self)->gc.gc_refs != _PyGC_REFS_UNTRACKED);
@@ -4088,6 +4088,7 @@ PyInit__testcapi(void)
     Py_TYPE(&_HashInheritanceTester_Type)=&PyType_Type;
 
     Py_TYPE(&test_structmembersType)=&PyType_Type;
+    PyType_Ready(&test_structmembersType);
     Py_INCREF(&test_structmembersType);
     /* don't use a name starting with "test", since we don't want
        test_capi to automatically call this */

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -4146,7 +4146,7 @@ sock_dealloc(PySocketSockObject *s)
     if (s->sock_fd != -1) {
         PyObject *exc, *val, *tb;
         Py_ssize_t old_refcount = Py_REFCNT(s);
-        ++Py_REFCNT(s);
+        ++_Py_REFCNT(s);
         PyErr_Fetch(&exc, &val, &tb);
         if (PyErr_WarnFormat(PyExc_ResourceWarning, 1,
                              "unclosed %R", s))
@@ -4155,7 +4155,7 @@ sock_dealloc(PySocketSockObject *s)
                 PyErr_WriteUnraisable((PyObject *) s);
         PyErr_Restore(exc, val, tb);
         (void) SOCKETCLOSE(s->sock_fd);
-        Py_REFCNT(s) = old_refcount;
+        _Py_REFCNT(s) = old_refcount;
     }
     Py_TYPE(s)->tp_free((PyObject *)s);
 }
@@ -6088,6 +6088,7 @@ PyInit__socket(void)
 #endif
 
     Py_TYPE(&sock_type) = &PyType_Type;
+    PyType_Ready(&sock_type);
     m = PyModule_Create(&socketmodule);
     if (m == NULL)
         return NULL;

--- a/Modules/unicodedata.c
+++ b/Modules/unicodedata.c
@@ -1343,6 +1343,7 @@ PyInit_unicodedata(void)
     PyObject *m, *v;
 
     Py_TYPE(&UCD_Type) = &PyType_Type;
+    PyType_Ready(&UCD_Type);
 
     m = PyModule_Create(&unicodedatamodule);
     if (!m)

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -188,13 +188,11 @@ static PyObject _dummy_struct;
 
 #define dummy (&_dummy_struct)
 
-#ifdef Py_REF_DEBUG
 PyObject *
 _PyDict_Dummy(void)
 {
     return dummy;
 }
-#endif
 
 /* forward declarations */
 static PyDictKeyEntry *lookdict(PyDictObject *mp, PyObject *key,
@@ -4240,6 +4238,6 @@ static PyTypeObject PyDictDummy_Type = {
 
 static PyObject _dummy_struct = {
   _PyObject_EXTRA_INIT
-  2, &PyDictDummy_Type
+  NULL, &PyDictDummy_Type
 };
 

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3450,7 +3450,7 @@ static PyObject *dictiter_iternextitem(dictiterobject *di)
     if (i > mask)
         goto fail;
 
-    if (result->ob_refcnt == 1) {
+    if (Py_REFCNT(result) == 1) {
         Py_INCREF(result);
         Py_DECREF(PyTuple_GET_ITEM(result, 0));
         Py_DECREF(PyTuple_GET_ITEM(result, 1));

--- a/Objects/enumobject.c
+++ b/Objects/enumobject.c
@@ -102,7 +102,7 @@ enum_next_long(enumobject *en, PyObject* next_item)
         return NULL;
     en->en_longindex = stepped_up;
 
-    if (result->ob_refcnt == 1) {
+    if (Py_REFCNT(result) == 1) {
         Py_INCREF(result);
         Py_DECREF(PyTuple_GET_ITEM(result, 0));
         Py_DECREF(PyTuple_GET_ITEM(result, 1));
@@ -141,7 +141,7 @@ enum_next(enumobject *en)
     }
     en->en_index++;
 
-    if (result->ob_refcnt == 1) {
+    if (Py_REFCNT(result) == 1) {
         Py_INCREF(result);
         Py_DECREF(PyTuple_GET_ITEM(result, 0));
         Py_DECREF(PyTuple_GET_ITEM(result, 1));

--- a/Objects/fileobject.c
+++ b/Objects/fileobject.c
@@ -94,7 +94,7 @@ PyFile_GetLine(PyObject *f, int n)
                             "EOF when reading a line");
         }
         else if (s[len-1] == '\n') {
-            if (result->ob_refcnt == 1)
+            if (Py_REFCNT(result) == 1)
                 _PyBytes_Resize(&result, len-1);
             else {
                 PyObject *v;

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5361,7 +5361,7 @@ _PyLong_Init(void)
             /* _Py_NewReference sets the ref count to 1 but
              * the ref count might be larger. Set the refcnt
              * to the original refcnt + 1 */
-            Py_REFCNT(op) = refcnt + 1;
+            Py_SET_REFCNT(op, refcnt + 1);
             assert(Py_SIZE(op) == size);
             assert(v->ob_digit[0] == (digit)abs(ival));
         }

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -33,9 +33,9 @@ PyModuleDef_Init(struct PyModuleDef* def)
 {
     if (PyType_Ready(&PyModuleDef_Type) < 0)
          return NULL;
+    _Py_MaybeNewReference(def);
     if (def->m_base.m_index == 0) {
         max_module_number++;
-        Py_SET_REFCNT(def, 1);
         Py_TYPE(def) = &PyModuleDef_Type;
         def->m_base.m_index = max_module_number;
     }

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -35,7 +35,7 @@ PyModuleDef_Init(struct PyModuleDef* def)
          return NULL;
     if (def->m_base.m_index == 0) {
         max_module_number++;
-        Py_REFCNT(def) = 1;
+        Py_SET_REFCNT(def, 1);
         Py_TYPE(def) = &PyModuleDef_Type;
         def->m_base.m_index = max_module_number;
     }

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -27,10 +27,10 @@ _Py_GetRefTotal(void)
        hash table code is well-tested) */
     o = _PyDict_Dummy();
     if (o != NULL)
-        total -= o->ob_refcnt;
+        total -= Py_REFCNT(o);
     o = _PySet_Dummy;
     if (o != NULL)
-        total -= o->ob_refcnt;
+        total -= Py_REFCNT(o);
     return total;
 }
 
@@ -215,7 +215,7 @@ _Py_NegativeRefcount(const char *fname, int lineno, PyObject *op)
     PyOS_snprintf(buf, sizeof(buf),
                   "%s:%i object at %p has negative ref count "
                   "%" PY_FORMAT_SIZE_T "d",
-                  fname, lineno, op, op->ob_refcnt);
+                  fname, lineno, op, Py_REFCNT(op));
     Py_FatalError(buf);
 }
 
@@ -302,27 +302,27 @@ PyObject_CallFinalizerFromDealloc(PyObject *self)
     Py_ssize_t refcnt;
 
     /* Temporarily resurrect the object. */
-    if (self->ob_refcnt != 0) {
+    if (Py_REFCNT(self) != 0) {
         Py_FatalError("PyObject_CallFinalizerFromDealloc called on "
                       "object with a non-zero refcount");
     }
-    self->ob_refcnt = 1;
+    Py_REFCNT(self) = 1;
 
     PyObject_CallFinalizer(self);
 
     /* Undo the temporary resurrection; can't use DECREF here, it would
      * cause a recursive call.
      */
-    assert(self->ob_refcnt > 0);
-    if (--self->ob_refcnt == 0)
+    assert(Py_REFCNT(self) > 0);
+    if (--Py_REFCNT(self) == 0)
         return 0;         /* this is the normal path out */
 
     /* tp_finalize resurrected it!  Make it look like the original Py_DECREF
      * never happened.
      */
-    refcnt = self->ob_refcnt;
+    refcnt = Py_REFCNT(self);
     _Py_NewReference(self);
-    self->ob_refcnt = refcnt;
+    Py_REFCNT(self) = refcnt;
 
     if (PyType_IS_GC(Py_TYPE(self))) {
         assert(_PyGC_REFS(self) != _PyGC_REFS_UNTRACKED);
@@ -362,12 +362,12 @@ PyObject_Print(PyObject *op, FILE *fp, int flags)
         Py_END_ALLOW_THREADS
     }
     else {
-        if (op->ob_refcnt <= 0)
+        if (Py_REFCNT(op) <= 0)
             /* XXX(twouters) cast refcount to long until %zd is
                universally available */
             Py_BEGIN_ALLOW_THREADS
             fprintf(fp, "<refcnt %ld at %p>",
-                (long)op->ob_refcnt, op);
+                (long)Py_REFCNT(op), op);
             Py_END_ALLOW_THREADS
         else {
             PyObject *s;
@@ -449,7 +449,7 @@ _PyObject_Dump(PyObject* op)
             "refcount: %ld\n"
             "address : %p\n",
             Py_TYPE(op)==NULL ? "NULL" : Py_TYPE(op)->tp_name,
-            (long)op->ob_refcnt,
+            (long)Py_REFCNT(op),
             op);
     }
 }
@@ -939,7 +939,7 @@ PyObject_SetAttr(PyObject *v, PyObject *name, PyObject *value)
         return err;
     }
     Py_DECREF(name);
-    assert(name->ob_refcnt >= 1);
+    assert(PyObject(name) >= 1);
     if (tp->tp_getattr == NULL && tp->tp_getattro == NULL)
         PyErr_Format(PyExc_TypeError,
                      "'%.100s' object has no attributes "
@@ -1791,7 +1791,7 @@ void
 _Py_NewReference(PyObject *op)
 {
     _Py_INC_REFTOTAL;
-    op->ob_refcnt = 1;
+    Py_REFCNT(op) = 1;
     _Py_AddToAllObjects(op, 1);
     _Py_INC_TPALLOCS(op);
 }
@@ -1802,7 +1802,7 @@ _Py_ForgetReference(PyObject *op)
 #ifdef SLOW_UNREF_CHECK
     PyObject *p;
 #endif
-    if (op->ob_refcnt < 0)
+    if (Py_REFCNT(op) < 0)
         Py_FatalError("UNREF negative refcnt");
     if (op == &refchain ||
         op->_ob_prev->_ob_next != op || op->_ob_next->_ob_prev != op) {
@@ -1845,7 +1845,7 @@ _Py_PrintReferences(FILE *fp)
     PyObject *op;
     fprintf(fp, "Remaining objects:\n");
     for (op = refchain._ob_next; op != &refchain; op = op->_ob_next) {
-        fprintf(fp, "%p [%" PY_FORMAT_SIZE_T "d] ", op, op->ob_refcnt);
+        fprintf(fp, "%p [%" PY_FORMAT_SIZE_T "d] ", op, Py_REFCNT(op));
         if (PyObject_Print(op, fp, 0) != 0)
             PyErr_Clear();
         putc('\n', fp);
@@ -1862,7 +1862,7 @@ _Py_PrintReferenceAddresses(FILE *fp)
     fprintf(fp, "Remaining object addresses:\n");
     for (op = refchain._ob_next; op != &refchain; op = op->_ob_next)
         fprintf(fp, "%p [%" PY_FORMAT_SIZE_T "d] %s\n", op,
-            op->ob_refcnt, Py_TYPE(op)->tp_name);
+            Py_REFCNT(op), Py_TYPE(op)->tp_name);
 }
 
 PyObject *
@@ -2007,7 +2007,7 @@ _PyTrash_deposit_object(PyObject *op)
 {
     assert(PyObject_IS_GC(op));
     assert(_PyGC_REFS(op) == _PyGC_REFS_UNTRACKED);
-    assert(op->ob_refcnt == 0);
+    assert(Py_REFCNT(op) == 0);
     _Py_AS_GC(op)->gc.gc_prev = (PyGC_Head *)_PyTrash_delete_later;
     _PyTrash_delete_later = op;
 }
@@ -2019,7 +2019,7 @@ _PyTrash_thread_deposit_object(PyObject *op)
     PyThreadState *tstate = PyThreadState_GET();
     assert(PyObject_IS_GC(op));
     assert(_PyGC_REFS(op) == _PyGC_REFS_UNTRACKED);
-    assert(op->ob_refcnt == 0);
+    assert(Py_REFCNT(op) == 0);
     _Py_AS_GC(op)->gc.gc_prev = (PyGC_Head *) tstate->trash_delete_later;
     tstate->trash_delete_later = op;
 }
@@ -2043,7 +2043,7 @@ _PyTrash_destroy_chain(void)
          * assorted non-release builds calling Py_DECREF again ends
          * up distorting allocation statistics.
          */
-        assert(op->ob_refcnt == 0);
+        assert(Py_REFCNT(op) == 0);
         ++_PyTrash_delete_nesting;
         (*dealloc)(op);
         --_PyTrash_delete_nesting;
@@ -2068,7 +2068,7 @@ _PyTrash_thread_destroy_chain(void)
          * assorted non-release builds calling Py_DECREF again ends
          * up distorting allocation statistics.
          */
-        assert(op->ob_refcnt == 0);
+        assert(Py_REFCNT(op) == 0);
         ++tstate->trash_delete_nesting;
         (*dealloc)(op);
         --tstate->trash_delete_nesting;

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -2559,6 +2559,6 @@ static PyTypeObject _PySetDummy_Type = {
 
 static PyObject _dummy_struct = {
   _PyObject_EXTRA_INIT
-  2, &_PySetDummy_Type
+  NULL, &_PySetDummy_Type
 };
 

--- a/Objects/sliceobject.c
+++ b/Objects/sliceobject.c
@@ -87,7 +87,7 @@ PyTypeObject PyEllipsis_Type = {
 
 PyObject _Py_EllipsisObject = {
     _PyObject_EXTRA_INIT
-    1, &PyEllipsis_Type
+    NULL, &PyEllipsis_Type
 };
 
 

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -177,7 +177,7 @@ int
 PyTuple_SetItem(PyObject *op, Py_ssize_t i, PyObject *newitem)
 {
     PyObject **p;
-    if (!PyTuple_Check(op) || op->ob_refcnt != 1) {
+    if (!PyTuple_Check(op) || Py_REFCNT(op) != 1) {
         Py_XDECREF(newitem);
         PyErr_BadInternalCall();
         return -1;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4813,6 +4813,7 @@ PyType_Ready(PyTypeObject *type)
     assert((type->tp_flags & Py_TPFLAGS_READYING) == 0);
 
     type->tp_flags |= Py_TPFLAGS_READYING;
+    _Py_NewReference(type);
 
 #ifdef Py_TRACE_REFS
     /* PyType_Ready is the closest thing we have to a choke point

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1095,7 +1095,7 @@ subtype_dealloc(PyObject *self)
         }
         if (type->tp_del) {
             type->tp_del(self);
-            if (self->ob_refcnt > 0)
+            if (Py_REFCNT(self) > 0)
                 return;
         }
 
@@ -1163,7 +1163,7 @@ subtype_dealloc(PyObject *self)
 
     if (type->tp_del) {
         type->tp_del(self);
-        if (self->ob_refcnt > 0) {
+        if (Py_REFCNT(self) > 0) {
             /* Resurrected */
             goto endlabel;
         }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -172,12 +172,12 @@ extern "C" {
 #endif
 
 /* This dictionary holds all interned unicode strings.  Note that references
-   to strings in this dictionary are *not* counted in the string's ob_refcnt.
+   to strings in this dictionary are *not* counted in the string's refcount.
    When the interned string reaches a refcnt of 0 the string deallocation
    function will delete the reference from this dictionary.
 
    Another way to look at this is that to say that the actual reference
-   count of a string is:  s->ob_refcnt + (s->state ? 2 : 0)
+   count of a string is:  Py_REFCNT(s) + (s->state ? 2 : 0)
 */
 static PyObject *interned = NULL;
 

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -1745,7 +1745,7 @@ unicode_dealloc(PyObject *unicode)
 
     case SSTATE_INTERNED_MORTAL:
         /* revive dead object temporarily for DelItem */
-        Py_REFCNT(unicode) = 3;
+        _Py_REFCNT(unicode) = 3;
         if (PyDict_DelItem(interned, unicode) != 0)
             Py_FatalError(
                 "deletion of interned string failed");
@@ -15271,7 +15271,7 @@ PyUnicode_InternInPlace(PyObject **p)
     PyThreadState_GET()->recursion_critical = 0;
     /* The two references in interned are not counted by refcnt.
        The deallocator will take care of this */
-    Py_REFCNT(s) -= 2;
+    _Py_REFCNT(s) -= 2;
     _PyUnicode_STATE(s).interned = SSTATE_INTERNED_MORTAL;
 }
 
@@ -15330,11 +15330,11 @@ _Py_ReleaseInternedUnicodeStrings(void)
             /* XXX Shouldn't happen */
             break;
         case SSTATE_INTERNED_IMMORTAL:
-            Py_REFCNT(s) += 1;
+            _Py_REFCNT(s) += 1;
             immortal_size += PyUnicode_GET_LENGTH(s);
             break;
         case SSTATE_INTERNED_MORTAL:
-            Py_REFCNT(s) += 2;
+            _Py_REFCNT(s) += 2;
             mortal_size += PyUnicode_GET_LENGTH(s);
             break;
         default:

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -886,7 +886,7 @@ PyObject_ClearWeakRefs(PyObject *object)
 
     if (object == NULL
         || !PyType_SUPPORTS_WEAKREFS(Py_TYPE(object))
-        || object->ob_refcnt != 0) {
+        || Py_REFCNT(object) != 0) {
         PyErr_BadInternalCall();
         return;
     }
@@ -909,7 +909,7 @@ PyObject_ClearWeakRefs(PyObject *object)
             current->wr_callback = NULL;
             clear_weakref(current);
             if (callback != NULL) {
-                if (((PyObject *)current)->ob_refcnt > 0)
+                if (Py_REFCNT((PyObject *)current) > 0)
                     handle_callback(current, callback);
                 Py_DECREF(callback);
             }
@@ -927,7 +927,7 @@ PyObject_ClearWeakRefs(PyObject *object)
             for (i = 0; i < count; ++i) {
                 PyWeakReference *next = current->wr_next;
 
-                if (((PyObject *)current)->ob_refcnt > 0)
+                if (Py_REFCNT((PyObject *)current) > 0)
                 {
                     Py_INCREF(current);
                     PyTuple_SET_ITEM(tuple, i * 2, (PyObject *) current);

--- a/Python/pyarena.c
+++ b/Python/pyarena.c
@@ -169,7 +169,7 @@ PyArena_Free(PyArena *arena)
     block_free(arena->a_head);
     /* This property normally holds, except when the code being compiled
        is sys.getobjects(0), in which case there will be two references.
-    assert(arena->a_objects->ob_refcnt == 1);
+    assert(Py_REFCNT(arena->a_objects) == 1);
     */
 
     Py_DECREF(arena->a_objects);

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1012,7 +1012,7 @@ Return the size of object in bytes.");
 static PyObject *
 sys_getrefcount(PyObject *self, PyObject *arg)
 {
-    return PyLong_FromSsize_t(arg->ob_refcnt);
+    return PyLong_FromSsize_t(Py_REFCNT(arg));
 }
 
 #ifdef Py_REF_DEBUG


### PR DESCRIPTION
Implement remote refcounts, storing a pointer to a refcount, which are allocated in blocks. The blocks aren't freed and there is no detection of refcount-value-leaks (different from refleaks) just yet. I have things in mind for both of them.
