### PR TITLE
PY_REFCNT -> Py_REFCNT.

### DIFF
--- a/Objects/object.c
+++ b/Objects/object.c
@@ -942,7 +942,7 @@ PyObject_SetAttr(PyObject *v, PyObject *name, PyObject *value)
         return err;
     }
     Py_DECREF(name);
-    assert(PY_REFCNT(name) >= 1);
+    assert(Py_REFCNT(name) >= 1);
     if (tp->tp_getattr == NULL && tp->tp_getattro == NULL)
         PyErr_Format(PyExc_TypeError,
                      "'%.100s' object has no attributes "


### PR DESCRIPTION
The gilectomy branch currently doesn't compile due to this typo.
