### PR TITLE
WIP: Initialize locks in __new__().

### DIFF
--- a/Include/lock.h
+++ b/Include/lock.h
@@ -86,6 +86,10 @@ typedef struct {
 #endif
 } futex_t;
 
+Py_LOCAL_INLINE(void) futex_init(futex_t *f) {
+    futex_init_primitive(&f->futex);
+}
+
 Py_LOCAL_INLINE(void) futex_lock(futex_t *f) {
 #ifdef FUTEX_WANT_STATS
 	unsigned int _;
@@ -159,6 +163,7 @@ typedef struct {
 #define FURTEX_STATIC_INIT(description) { FUTEX_STATIC_INIT(description), 0, 0, description, NULL, 0, FURTEX_STATS_STATIC_INIT }
 Py_LOCAL_INLINE(void) furtex_init(furtex_t *f) {
 	memset(f, 0, sizeof(*f));
+    futex_init(&f->futex);
 }
 #define furtex_lock(f) (_furtex_lock(f, __FILE__, __LINE__))
 Py_LOCAL_INLINE(void) _furtex_lock(furtex_t *f, const char *file, int line) {

--- a/Include/lock_pthreads.h
+++ b/Include/lock_pthreads.h
@@ -31,6 +31,7 @@ Py_LOCAL_INLINE(void) futex_init_primitive(primitivelock_t *lock) {
 
 Py_LOCAL_INLINE(void) futex_lock_primitive(primitivelock_t *lock) {
 	pthread_lock_t* f = (pthread_lock_t*)lock;
+    /* assert(f->initialized); */
 	if (!f->initialized) {
 		futex_init_primitive(lock);
 	}

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2534,6 +2534,7 @@ list_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (result == NULL) {
         return NULL;
     }
+    list_lock_new((PyListObject *)result);
     return result;
 }
 

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2527,6 +2527,16 @@ list_richcompare(PyObject *v, PyObject *w, int op)
     return result;
 }
 
+static PyObject *
+list_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+{
+    PyObject *result = PyType_GenericNew(type, args, kwds);
+    if (result == NULL) {
+        return NULL;
+    }
+    return result;
+}
+
 static int
 list_init(PyListObject *self, PyObject *args, PyObject *kw)
 {
@@ -2938,7 +2948,7 @@ PyTypeObject PyList_Type = {
     0,                                          /* tp_dictoffset */
     (initproc)list_init,                        /* tp_init */
     PyType_GenericAlloc,                        /* tp_alloc */
-    PyType_GenericNew,                          /* tp_new */
+    list_new,                                   /* tp_new */
     PyObject_GC_Del,                            /* tp_free */
 
 


### PR DESCRIPTION
(see issue #20)

Locks need to be initialized before objects become available for mutation in Python.  That means doing so in **new**().  A number of types current have tp_new set to PyType_GenericNew.  Others have their own tp_new implementation.  In both cases the respective locks must be initialized in whatever is set in tp_new.

Note on WIP: This PR will grow as more and more types are fixed.
