### PR TITLE
To_nano variable named changed to cycles_to_nanosecond.

### DIFF
--- a/Include/lock_pthreads.h
+++ b/Include/lock_pthreads.h
@@ -69,7 +69,7 @@ Py_LOCAL_INLINE(double) cycle_count_to_seconds(uint64_t cycles) {
 	if (cycles_to_nanoseconds == -1) {
 		mach_timebase_info_data_t sTimebaseInfo;
 		mach_timebase_info(&sTimebaseInfo);
-		to_nano = (double)sTimebaseInfo.numer / (double)sTimebaseInfo.denom;
+		cycles_to_nanoseconds = (double)sTimebaseInfo.numer / (double)sTimebaseInfo.denom;
 	}
 
 	return (cycles * cycles_to_nanoseconds) / 1000000000;


### PR DESCRIPTION
It appears that the to_nano variable was refactored into
cycles_to_nanosecond but the variable name wasn’t changed it all places
preventing the build.
